### PR TITLE
feat: checkoutステップのrefオプションをGitHub Actionsから削除

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,6 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      time: "06:00"
+      timezone: "Asia/Tokyo"

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - Dockerfile
+  workflow_dispatch:
 
 jobs:
   hadolint:
@@ -12,8 +13,6 @@ jobs:
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: hadolint/hadolint-action@v3.0.0
         with:
           ignore: DL4006

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -9,8 +11,6 @@ jobs:
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
@@ -25,8 +25,6 @@ jobs:
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ github.token }}
@@ -41,8 +39,6 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"


### PR DESCRIPTION
# やったこと

- checkoutステップのrefオプションをGitHub Actionsから削除
- 毎日6時にdependabotが実行されるよう設定

# やらなかったこと

- なし

# 補足

- なし
